### PR TITLE
Make info in seminars page copyable; eliminate animations.

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -304,7 +304,6 @@ ul
 
 .pn-seminar
 {
-  cursor: pointer;
   margin-bottom: 25px;
 }
 
@@ -315,13 +314,9 @@ ul
     font-family: 'Ubuntu', sans-serif;
     font-size: 26px;
     line-height: 26px;
-    margin-bottom: 10px; 
-    color: white;
-}
-
-.pn-seminar .pn-title
-{
-  color: #5eb6ef;
+    margin-bottom: 10px;
+    color: #5eb6ef;
+    cursor: pointer;
 }
 
 .pn-seminar.compact.finished .pn-name, .pn-seminar.finished .pn-title-separator, .pn-seminar.finished .pn-title

--- a/js/custom.js
+++ b/js/custom.js
@@ -80,36 +80,25 @@ else
       }, 1000 );
     }); 
 
-    $('.pn-seminar').click(function()
+    $('.pn-seminar .pn-title').click(function()
     {
-      $this = $(this);
+      $this = $(this).closest(".pn-seminar");
 
       if( $this.hasClass( 'compact' ) )
-      { 
-        $this.find('.pn-main-informations').fadeOut( function()
-        {      
-            $this.find('br').remove();    
-            $this.find('.pn-title, .pn-url').after('<br />');  
+      {
+            $this.find('br').remove();
+            $this.find('.pn-title, .pn-url').after('<br />');
 
-            $this.find('.pn-abstract-bio').slideDown();    
-            $this.find('.pn-main-informations').fadeIn();
-            
-            $this.removeClass( 'compact' );   
-        });      
+            $this.find('.pn-abstract-bio').show();
+
+            $this.removeClass( 'compact' );
       }
       else
-      { 
-        $this.find('.pn-abstract-bio').slideUp( function()
-        {
-            $this.find('.pn-main-informations').fadeOut( function()
-            {
-                $this.find('br').remove();   
-                $this.find('.pn-name').after('<br />').before('<br />');       
-                
-                $this.find('.pn-main-informations').fadeIn();
-                $this.addClass( 'compact' );  
-            });
-        });
+      {
+        $this.find('.pn-abstract-bio').hide();
+        $this.find('br').remove();
+        $this.find('.pn-name').after('<br />').before('<br />');
+        $this.addClass( 'compact' );
       }
     });
   });


### PR DESCRIPTION
This makes it so only clicking on the titles of the seminars triggers the expansion/contraction, rather than the whole block, which means you can actually copy and paste out of the rest (and in general it is less annoying). I also got rid of the scroll/fade animation, as it was somewhat broken (flickering stuff that shouldn't flicker), and I think in general just making things worse. 

Is this okay @bennn and @schuster ? (and anyone else who wants to weigh in?)
